### PR TITLE
preserve modal element

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,16 +4,17 @@ var document = require('global/document')
 var onload = require('on-load')
 
 module.exports = function modalElement (contents) {
-  var el = render(contents)
+  var el = render(true, contents)
+  var hidden
   function modalShow (newContents) {
     if (newContents) contents = newContents
-    yo.update(el, render(contents))
+    yo.update(el, render(true, contents))
   }
   function modalHide () {
-    el.style.display = 'none'
+    yo.update(el, render(false))
   }
   function modalToggle (newContents) {
-    if (!el || el.style.display === 'none') {
+    if (hidden) {
       modalShow(newContents)
     } else {
       modalHide()
@@ -35,22 +36,25 @@ module.exports = function modalElement (contents) {
   el.toggle = modalToggle
   return el
 
-  function render (contents) {
+  function render (show, contents) {
+    hidden = !show
     var modal = yo`<div class="modal">${contents}</div>`
     var overlay = yo`<div class="modal-overlay">${modal}</div>`
-    onload(overlay, function () {
-      document.addEventListener('mousedown', didClickOut, false)
-    }, function () {
-      document.removeEventListener('mousedown', didClickOut, false)
-    })
-    assign(overlay.style, {
-      position: 'fixed',
-      height: '100%',
-      width: '100%',
-      top: 0,
-      left: 0,
-      'z-index': '9999'
-    })
+    if (show) {
+      onload(overlay, function () {
+        document.addEventListener('mousedown', didClickOut, false)
+      }, function () {
+        document.removeEventListener('mousedown', didClickOut, false)
+      })
+      assign(overlay.style, {
+        position: 'fixed',
+        height: '100%',
+        width: '100%',
+        top: 0,
+        left: 0,
+        'z-index': '9999'
+      })
+    }
     return overlay
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,17 +4,19 @@ var document = require('global/document')
 var onload = require('on-load')
 
 module.exports = function modalElement (contents) {
-  var el = render(true, contents)
-  var hidden
+  var active = true
+  var el = render(contents)
   function modalShow (newContents) {
     if (newContents) contents = newContents
-    yo.update(el, render(true, contents))
+    active = true
+    yo.update(el, render(contents))
   }
   function modalHide () {
-    yo.update(el, render(false))
+    active = false
+    yo.update(el, render())
   }
   function modalToggle (newContents) {
-    if (hidden) {
+    if (!active) {
       modalShow(newContents)
     } else {
       modalHide()
@@ -36,11 +38,10 @@ module.exports = function modalElement (contents) {
   el.toggle = modalToggle
   return el
 
-  function render (show, contents) {
-    hidden = !show
+  function render (contents) {
     var modal = yo`<div class="modal">${contents}</div>`
     var overlay = yo`<div class="modal-overlay">${modal}</div>`
-    if (show) {
+    if (active) {
       onload(overlay, function () {
         document.addEventListener('mousedown', didClickOut, false)
       }, function () {

--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ module.exports = function modalElement (contents) {
   var el = render(contents)
   function modalShow (newContents) {
     if (newContents) contents = newContents
-    el = yo.update(el, render(contents))
+    yo.update(el, render(contents))
   }
   function modalHide () {
-    el = yo.update(el, document.createTextNode(''))
+    el.style.display = 'none'
   }
   function modalToggle (newContents) {
-    if (!el || el.nodeName === '#text') {
+    if (!el || el.style.display === 'none') {
       modalShow(newContents)
     } else {
       modalHide()

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,23 @@ test('remove and re-create the contents', function (t) {
   t.end()
 })
 
+test('toggle the contents', function (t) {
+  var modal = modalElement(yo`
+    <div class='test'>modal!</div>
+  `)
+  modal.toggle()
+  t.equal(modal.style.display, 'none')
+  body = getBody(modal)
+  t.equal(body.className, 'test')
+  t.equal(body.innerHTML, 'modal!')
+  modal.toggle()
+  t.equal(modal.style.display, '')
+  body = getBody(modal)
+  t.equal(body.className, 'test')
+  t.equal(body.innerHTML, 'modal!')
+  t.end()
+})
+
 function isModal (t, modal) {
   t.ok(modal instanceof HTMLDivElement)
   t.equal(modal.className, 'modal-overlay')

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,7 @@ test('remove the contents', function (t) {
     <div class='test'>modal!</div>
   `)
   modal.hide()
+  t.equal(modal.style.display, 'none')
   var body = getBody(modal)
   t.equal(body.className, 'test')
   t.equal(body.innerHTML, 'modal!')
@@ -55,7 +56,9 @@ test('remove and re-create the contents', function (t) {
     <div class='test'>modal!</div>
   `)
   var body = getBody(modal)
-  t.equal(body, undefined)
+  t.equal(modal.style.display, '')
+  t.equal(body.className, 'test')
+  t.equal(body.innerHTML, 'modal!')
   t.end()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -42,10 +42,8 @@ test('remove the contents', function (t) {
     <div class='test'>modal!</div>
   `)
   modal.hide()
-  t.equal(modal.style.display, 'none')
   var body = getBody(modal)
-  t.equal(body.className, 'test')
-  t.equal(body.innerHTML, 'modal!')
+  t.equal(body, undefined)
   t.end()
 })
 
@@ -56,7 +54,6 @@ test('remove and re-create the contents', function (t) {
     <div class='test'>modal!</div>
   `)
   var body = getBody(modal)
-  t.equal(modal.style.display, '')
   t.equal(body.className, 'test')
   t.equal(body.innerHTML, 'modal!')
   t.end()
@@ -67,15 +64,15 @@ test('toggle the contents', function (t) {
     <div class='test'>modal!</div>
   `)
   modal.toggle()
-  t.equal(modal.style.display, 'none')
+  var body = getBody(modal)
+  t.equal(body, undefined)
+  modal.toggle()
   body = getBody(modal)
   t.equal(body.className, 'test')
   t.equal(body.innerHTML, 'modal!')
   modal.toggle()
-  t.equal(modal.style.display, '')
   body = getBody(modal)
-  t.equal(body.className, 'test')
-  t.equal(body.innerHTML, 'modal!')
+  t.equal(body, undefined)
   t.end()
 })
 


### PR DESCRIPTION
hey @shama, here's an alternative to https://github.com/shama/modal-element/pull/6.

previously, `modal.hide()` morphed the element into an empty text node, which means the element returned by the factory function `modalElement()` no longer matches the next element shown with `modal.show()`.

this changes `modal.hide()` to reset the modal contents to be empty (including no overlay styles or onload), so when `modal.show()` is called later `modal` still references the same element being displayed.
